### PR TITLE
Upgrade just to 1.52.0

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,5 +1,5 @@
 [tools]
-just = "1.46.0"
+just = "1.52.0"
 "pipx:pre-commit" = "4.3.0"
 python = "3.12.11"
 uv = "0.8.11"


### PR DESCRIPTION
Bumps the pinned `just` version to 1.52.0 in `.mise/config.toml` to match the project-template baseline.